### PR TITLE
rename beforeDestroy to beforeUnmount

### DIFF
--- a/lib/vue-slider.vue
+++ b/lib/vue-slider.vue
@@ -528,7 +528,7 @@ export default {
   mounted() {
     this.bindEvent()
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.unbindEvent()
   },
   methods: {


### PR DESCRIPTION
Rename `beforeDestroy` lifetime hook to `beforeUnmount`, because it doesn't work in Vue 3