### PR TITLE
Fix non-passive event listener

### DIFF
--- a/lib/vue-slider-dot.vue
+++ b/lib/vue-slider-dot.vue
@@ -4,7 +4,7 @@
     :class="dotClasses"
     :aria-valuetext="tooltipValue"
     @mousedown="dragStart"
-    @touchstart="dragStart"
+    @touchstart.passive="dragStart"
   >
     <slot name="dot">
       <div :class="handleClasses" :style="dotStyle" />

--- a/lib/vue-slider.vue
+++ b/lib/vue-slider.vue
@@ -4,7 +4,7 @@
     :class="containerClasses"
     :style="containerStyles"
     @click="clickHandle"
-    @touchstart="dragStartOnProcess"
+    @touchstart.passive="dragStartOnProcess"
     @mousedown="dragStartOnProcess"
     v-bind="$attrs"
   >


### PR DESCRIPTION
## Summary
Fix the following violations.
https://vue-3-slider-component.netlify.app/?path=/docs/vue-3-slider-component--vue-3-slider-component
![image](https://github.com/s-sasaki-0529/vue-slider-component/assets/16841915/84676930-4fdd-48aa-b770-b97073d308ce)
> [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952


## Detail
A `touchstart` event causes scrolling action as default.
However, a browser is unable to start scrolling until the event listener has finished,
because the event listener might cancel the action by calling `preventDefault()`.
If the event listener takes too long to execute, this can cause a 'scroll jank'.

By setting the `passive` option, an event listener declares that it will not cancel the default action,
so the browser can start scrolling asynchronously, without waiting for the listener to finish.

See also https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners